### PR TITLE
feat: support terra.js 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,47 @@ function Component() {
 
 - [한국어 (Notion)](https://www.notion.so/terramoneyteam/terra-money-wallet-provider-0-14-0-49a62205608c4e0085e1c8f5361ccc46)
 
+# Known issues
+
+<details>
+
+<summary>terra.js version conflict</summary>
+
+Dependence on `terra.js` is set to `^1.8.0 || ^2.0.0`
+
+If your dependencies are like this,
+
+```json
+{
+  "dependencies": {
+    "@terra-money/terra.js": "^1.8.9",
+    "@terra-money/wallet-provider": "^2.0.0"
+  }
+}
+```
+
+For `npm`, the `terra.js` of `~/node_modules` tree will all be `1.8.9` or higher.
+
+However, if `yarn` is used, there is a problem that both `^1.8.0` and `^2.0.0` are installed (probably there is a problem that cannot handle the or).
+
+If `yarn` is used (including both classic and berry)
+
+```json
+{
+  "dependencies": {
+    "@terra-money/terra.js": "^1.8.9",
+    "@terra-money/wallet-provider": "^2.0.0"
+  },
+  "resolutions": {
+    "@terra-money/terra.js": "1.8.9"
+  }
+}
+```
+
+If you set `resolution` as above, all `terra.js` will be `^1.8.0`.
+
+</details>
+
 # For Chrome Extension compatible wallet developers
 
 <details>

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ If your dependencies are like this,
 
 For `npm`, the `terra.js` of `~/node_modules` tree will all be `1.8.9` or higher.
 
-However, if `yarn` is used, there is a problem that both `^1.8.0` and `^2.0.0` are installed (probably there is a problem that cannot handle the or).
+However, if `yarn` is used, there is a problem that both `^1.8.0` and `^2.0.0` are installed (probably there is a problem that cannot handle the `||`).
 
 If `yarn` is used (including both classic and berry)
 

--- a/packages/.packages.json
+++ b/packages/.packages.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://rocket-hangar.github.io/rocket-punch/schemas/packages.json",
   "@terra-dev/*": {
-    "version": "2.0.0-alpha.1",
+    "version": "2.0.0-alpha.2",
     "tag": "canary"
   },
   "@terra-money/*": {
-    "version": "2.0.0-alpha.1",
+    "version": "2.0.0-alpha.2",
     "tag": "canary"
   }
 }

--- a/packages/.packages.json
+++ b/packages/.packages.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://rocket-hangar.github.io/rocket-punch/schemas/packages.json",
   "@terra-dev/*": {
-    "version": "1.4.0-alpha.3",
+    "version": "2.0.0-alpha.1",
     "tag": "canary"
   },
   "@terra-money/*": {
-    "version": "1.4.0-alpha.3",
+    "version": "2.0.0-alpha.1",
     "tag": "canary"
   }
 }

--- a/packages/.packages.json
+++ b/packages/.packages.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://rocket-hangar.github.io/rocket-punch/schemas/packages.json",
   "@terra-dev/*": {
-    "version": "2.0.0-alpha.2",
-    "tag": "canary"
+    "version": "2.0.0",
+    "tag": "latest"
   },
   "@terra-money/*": {
-    "version": "2.0.0-alpha.2",
-    "tag": "canary"
+    "version": "2.0.0",
+    "tag": "latest"
   }
 }

--- a/packages/package.json
+++ b/packages/package.json
@@ -40,8 +40,8 @@
     ]
   },
   "dependencies": {
-    "@terra-dev/web-extension": "^0.4.0",
-    "@terra-money/terra.js": "^1.8.9",
+    "@terra-dev/web-extension": "^0.5.2",
+    "@terra-money/terra.js": "^2.0.1",
     "@walletconnect/core": "^1.6.1",
     "@walletconnect/iso-crypto": "^1.6.1",
     "@walletconnect/types": "^1.6.1",

--- a/packages/scripts/build.ts
+++ b/packages/scripts/build.ts
@@ -36,7 +36,7 @@ build({
     }
     
     if ('@terra-money/terra.js' in dependencies) {
-      dependencies['@terra-money/terra.js'] = '^1.8.0';
+      dependencies['@terra-money/terra.js'] = '^1.8.0 || ^2.0.0';
     }
 
     //switch (packageName) {

--- a/packages/src/@terra-dev/walletconnect/connect.ts
+++ b/packages/src/@terra-dev/walletconnect/connect.ts
@@ -2,7 +2,6 @@ import { isMobile } from '@terra-dev/browser-check';
 import { TerraWalletconnectQrcodeModal } from '@terra-dev/walletconnect-qrcode-modal';
 import { CreateTxOptions } from '@terra-money/terra.js';
 import Connector from '@walletconnect/core';
-import { selectRandomBridgeUrl } from '@walletconnect/core/dist/esm/url';
 import * as cryptoLib from '@walletconnect/iso-crypto';
 import {
   IPushServerOptions,
@@ -31,7 +30,7 @@ export interface WalletConnectControllerOptions {
    * @default
    * ```js
    * {
-   *   bridge: selectRandomBridgeUrl(),
+   *   bridge: 'https://tequila-walletconnect.terra.dev/',
    *   qrcodeModal: new TerraWalletconnectQrcodeModal(),
    * }
    * ```
@@ -82,7 +81,7 @@ export function connect(
     options.connectorOpts?.qrcodeModal ?? new TerraWalletconnectQrcodeModal();
 
   const connectorOpts: IWalletConnectOptions = {
-    bridge: selectRandomBridgeUrl(),
+    bridge: 'https://tequila-walletconnect.terra.dev/',
     qrcodeModal,
     ...options.connectorOpts,
   };

--- a/packages/src/@terra-money/wallet-provider/README.md
+++ b/packages/src/@terra-money/wallet-provider/README.md
@@ -313,6 +313,47 @@ function Component() {
 
 - [한국어 (Notion)](https://www.notion.so/terramoneyteam/terra-money-wallet-provider-0-14-0-49a62205608c4e0085e1c8f5361ccc46)
 
+# Known issues
+
+<details>
+
+<summary>terra.js version conflict</summary>
+
+Dependence on `terra.js` is set to `^1.8.0 || ^2.0.0`
+
+If your dependencies are like this,
+
+```json
+{
+  "dependencies": {
+    "@terra-money/terra.js": "^1.8.9",
+    "@terra-money/wallet-provider": "^2.0.0"
+  }
+}
+```
+
+For `npm`, the `terra.js` of `~/node_modules` tree will all be `1.8.9` or higher.
+
+However, if `yarn` is used, there is a problem that both `^1.8.0` and `^2.0.0` are installed (probably there is a problem that cannot handle the or).
+
+If `yarn` is used (including both classic and berry)
+
+```json
+{
+  "dependencies": {
+    "@terra-money/terra.js": "^1.8.9",
+    "@terra-money/wallet-provider": "^2.0.0"
+  },
+  "resolutions": {
+    "@terra-money/terra.js": "1.8.9"
+  }
+}
+```
+
+If you set `resolution` as above, all `terra.js` will be `^1.8.0`.
+
+</details>
+
 # For Chrome Extension compatible wallet developers
 
 <details>

--- a/packages/src/@terra-money/wallet-provider/README.md
+++ b/packages/src/@terra-money/wallet-provider/README.md
@@ -334,7 +334,7 @@ If your dependencies are like this,
 
 For `npm`, the `terra.js` of `~/node_modules` tree will all be `1.8.9` or higher.
 
-However, if `yarn` is used, there is a problem that both `^1.8.0` and `^2.0.0` are installed (probably there is a problem that cannot handle the or).
+However, if `yarn` is used, there is a problem that both `^1.8.0` and `^2.0.0` are installed (probably there is a problem that cannot handle the `||`).
 
 If `yarn` is used (including both classic and berry)
 

--- a/packages/src/components/TxSample.tsx
+++ b/packages/src/components/TxSample.tsx
@@ -23,7 +23,7 @@ export function TxSample() {
       return;
     }
 
-    if (!connectedWallet.network.chainID.startsWith('tequila')) {
+    if (connectedWallet.network.chainID.startsWith('columbus')) {
       alert(`Please only execute this example on Testnet`);
       return;
     }

--- a/templates/create-react-app/package.json
+++ b/templates/create-react-app/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@terra-money/terra.js": "^2.0.1",
-    "@terra-money/wallet-provider": "^2.0.0-alpha.2",
+    "@terra-money/wallet-provider": "^2.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0"

--- a/templates/create-react-app/package.json
+++ b/templates/create-react-app/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@terra-money/terra.js": "^2.0.1",
-    "@terra-money/wallet-provider": "^2.0.0-alpha.1",
+    "@terra-money/wallet-provider": "^2.0.0-alpha.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0"

--- a/templates/create-react-app/package.json
+++ b/templates/create-react-app/package.json
@@ -34,8 +34,8 @@
     ]
   },
   "dependencies": {
-    "@terra-money/terra.js": "^1.8.9",
-    "@terra-money/wallet-provider": "^1.2.4",
+    "@terra-money/terra.js": "^2.0.1",
+    "@terra-money/wallet-provider": "^2.0.0-alpha.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0"

--- a/templates/create-react-app/src/components/TxSample.tsx
+++ b/templates/create-react-app/src/components/TxSample.tsx
@@ -23,7 +23,7 @@ export function TxSample() {
       return;
     }
 
-    if (!connectedWallet.network.chainID.startsWith('tequila')) {
+    if (connectedWallet.network.chainID.startsWith('columbus')) {
       alert(`Please only execute this example on Testnet`);
       return;
     }

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -8,7 +8,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@terra-money/wallet-provider": "^2.0.0-alpha.1",
+    "@terra-money/wallet-provider": "^2.0.0-alpha.2",
     "next": "^11.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -8,7 +8,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@terra-money/wallet-provider": "^2.0.0-alpha.2",
+    "@terra-money/wallet-provider": "^2.0.0",
     "next": "^11.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -8,7 +8,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@terra-money/wallet-provider": "^1.2.4",
+    "@terra-money/wallet-provider": "^2.0.0-alpha.1",
     "next": "^11.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/templates/next/pages/tx-sample.tsx
+++ b/templates/next/pages/tx-sample.tsx
@@ -23,7 +23,7 @@ export default function TxSample() {
       return;
     }
 
-    if (!connectedWallet.network.chainID.startsWith('tequila')) {
+    if (connectedWallet.network.chainID.startsWith('columbus')) {
       alert(`Please only execute this example on Testnet`);
       return;
     }

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -30,11 +30,12 @@
   },
   "dependencies": {
     "@terra-money/terra.js": "^2.0.1",
-    "@terra-money/wallet-provider": "^2.0.0-alpha.1",
+    "@terra-money/wallet-provider": "^2.0.0-alpha.2",
     "buffer": "^6.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^5.2.0"
+    "react-router-dom": "^5.2.0",
+    "vite-compatible-readable-stream": "^3.6.0"
   },
   "devDependencies": {
     "@peculiar/webcrypto": "^1.1.7",

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@terra-money/terra.js": "^2.0.1",
-    "@terra-money/wallet-provider": "^2.0.0-alpha.2",
+    "@terra-money/wallet-provider": "^2.0.0",
     "buffer": "^6.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -29,8 +29,8 @@
     ]
   },
   "dependencies": {
-    "@terra-money/terra.js": "^1.8.9",
-    "@terra-money/wallet-provider": "^1.2.4",
+    "@terra-money/terra.js": "^2.0.1",
+    "@terra-money/wallet-provider": "^2.0.0-alpha.1",
     "buffer": "^6.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/templates/vite/src/components/TxSample.tsx
+++ b/templates/vite/src/components/TxSample.tsx
@@ -23,7 +23,7 @@ export function TxSample() {
       return;
     }
 
-    if (!connectedWallet.network.chainID.startsWith('tequila')) {
+    if (connectedWallet.network.chainID.startsWith('columbus')) {
       alert(`Please only execute this example on Testnet`);
       return;
     }

--- a/templates/vite/vite.config.ts
+++ b/templates/vite/vite.config.ts
@@ -8,8 +8,9 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 export default defineConfig({
   resolve: {
     alias: {
-      '@terra-money/terra.js': '@terra-money/terra.js/dist/bundle.js',
+      //'@terra-money/terra.js': '@terra-money/terra.js/dist/bundle.js',
       'process': path.resolve(__dirname, 'src/polyfills/process-es6.js'),
+      'readable-stream': 'vite-compatible-readable-stream',
     },
   },
   //define: {

--- a/templates/wallet-controller/package.json
+++ b/templates/wallet-controller/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@terra-money/terra.js": "^2.0.1",
-    "@terra-money/wallet-provider": "^2.0.0-alpha.1",
+    "@terra-money/wallet-provider": "^2.0.0-alpha.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/templates/wallet-controller/package.json
+++ b/templates/wallet-controller/package.json
@@ -34,8 +34,8 @@
     ]
   },
   "dependencies": {
-    "@terra-money/terra.js": "^1.8.9",
-    "@terra-money/wallet-provider": "^1.2.4",
+    "@terra-money/terra.js": "^2.0.1",
+    "@terra-money/wallet-provider": "^2.0.0-alpha.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/templates/wallet-controller/package.json
+++ b/templates/wallet-controller/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@terra-money/terra.js": "^2.0.1",
-    "@terra-money/wallet-provider": "^2.0.0-alpha.2",
+    "@terra-money/wallet-provider": "^2.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/templates/wallet-controller/src/index.ts
+++ b/templates/wallet-controller/src/index.ts
@@ -134,7 +134,7 @@ combineLatest([
         txPre.textContent = '';
 
         const send = () => {
-          if (!states.network.chainID.startsWith('tequila')) {
+          if (states.network.chainID.startsWith('columbus')) {
             alert(`Please only execute this example on Testnet`);
             return;
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3029,50 +3029,50 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terra-dev/browser-check@npm:^2.0.0-alpha.2":
-  version: 2.0.0-alpha.2
-  resolution: "@terra-dev/browser-check@npm:2.0.0-alpha.2"
+"@terra-dev/browser-check@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@terra-dev/browser-check@npm:2.0.0"
   dependencies:
     bowser: ^2.11.0
     mobile-detect: ^1.4.5
-  checksum: f6cff8dfaf3615da534100c553377f50da7aa62617f44f0280a3ede0922f88fb8dc4af30e4e436e68a807c29a42052c1f3b1f15a5c6b0888b47d6d6061d11959
+  checksum: 6b50c6859c54824d2872fc6120937f76cf0ba2ac749030c96c184cf2b87c43b20e17c37e52fcecd574691862cbaab2d478191754bb63b6b73acf831ed4a6ac30
   languageName: node
   linkType: hard
 
-"@terra-dev/chrome-extension@npm:^2.0.0-alpha.2":
-  version: 2.0.0-alpha.2
-  resolution: "@terra-dev/chrome-extension@npm:2.0.0-alpha.2"
+"@terra-dev/chrome-extension@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@terra-dev/chrome-extension@npm:2.0.0"
   dependencies:
-    "@terra-dev/browser-check": ^2.0.0-alpha.2
-    "@terra-dev/wallet-types": ^2.0.0-alpha.2
+    "@terra-dev/browser-check": ^2.0.0
+    "@terra-dev/wallet-types": ^2.0.0
     "@terra-money/terra.js": ^1.8.0 || ^2.0.0
     rxjs: ^7.3.0
-  checksum: cdff547f6361f4ddaca5850e6d98e70965afad2a4d07a63b6a0911d20ff34de1bde8647b7e846b4e0592c2aca132c5308dbc44954ecbb4def496039f7074bc8c
+  checksum: 5ee3499531df69c9bc981e7c0b9d45fb2d00ac74587ae1adf320c59aa0c598f552ac7cff10f1f753dd10f998da78a9d795dfaad2ed56c05deaef2f8150ec795b
   languageName: node
   linkType: hard
 
-"@terra-dev/readonly-wallet-modal@npm:^2.0.0-alpha.2":
-  version: 2.0.0-alpha.2
-  resolution: "@terra-dev/readonly-wallet-modal@npm:2.0.0-alpha.2"
+"@terra-dev/readonly-wallet-modal@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@terra-dev/readonly-wallet-modal@npm:2.0.0"
   dependencies:
-    "@terra-dev/readonly-wallet": ^2.0.0-alpha.2
-    "@terra-dev/wallet-types": ^2.0.0-alpha.2
+    "@terra-dev/readonly-wallet": ^2.0.0
+    "@terra-dev/wallet-types": ^2.0.0
     "@terra-money/terra.js": ^1.8.0 || ^2.0.0
     styled-components: ^5.0.0
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: dd6e687d68d48c7293b8c2274a53ab6775a05f252b9acdc1c774847fb138a876cb2543128982bfc9a7c4da502d80df5e84246b378eb3cc717252c768092302ac
+  checksum: b2e15130eb4f88975a52dee55540b0f43e02a52def8fca30bfa5a730346c1bf54da1855e897892e21bf9860a046b9e77292505880a922658de10ca92858354c8
   languageName: node
   linkType: hard
 
-"@terra-dev/readonly-wallet@npm:^2.0.0-alpha.2":
-  version: 2.0.0-alpha.2
-  resolution: "@terra-dev/readonly-wallet@npm:2.0.0-alpha.2"
+"@terra-dev/readonly-wallet@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@terra-dev/readonly-wallet@npm:2.0.0"
   dependencies:
-    "@terra-dev/wallet-types": ^2.0.0-alpha.2
+    "@terra-dev/wallet-types": ^2.0.0
     "@terra-money/terra.js": ^1.8.0 || ^2.0.0
-  checksum: 660d5582d46463d1cb3d1bede194ebf5a23067200ced884fd7130d945a8258d9aed6053b813d3e9509d5f9ac40792f1633d176e1b47f9ea4debded8b07f7bf65
+  checksum: 9306696b3427fda834ca3326b87842db40fbd9913a16d8613c41015061d5fc0ad6694f20a17bebf9cd92e475f02a0e69d86b49ea133ee4c910ab143625672b1c
   languageName: node
   linkType: hard
 
@@ -3087,12 +3087,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terra-dev/wallet-types@npm:^2.0.0-alpha.2":
-  version: 2.0.0-alpha.2
-  resolution: "@terra-dev/wallet-types@npm:2.0.0-alpha.2"
+"@terra-dev/wallet-types@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@terra-dev/wallet-types@npm:2.0.0"
   dependencies:
     "@terra-money/terra.js": ^1.8.0 || ^2.0.0
-  checksum: 83fae2c50f90c6daf11f0ca3ebfead444b01e3a19fd593e56d3dc33f814683e96729ff1c6bb69c33eb820cb43d384efa527a549294c6a7400ace72cb6c8d2d6e
+  checksum: 5448f9bcac3cd0fb8b1bbee0cc9aea4668920590e14fee6d45185728d3d611c5e75bb35537d5a354429874421c0c765876ce41838da80c41e6a31b6f6ce7bb42
   languageName: node
   linkType: hard
 
@@ -3106,27 +3106,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terra-dev/walletconnect-qrcode-modal@npm:^2.0.0-alpha.2":
-  version: 2.0.0-alpha.2
-  resolution: "@terra-dev/walletconnect-qrcode-modal@npm:2.0.0-alpha.2"
+"@terra-dev/walletconnect-qrcode-modal@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@terra-dev/walletconnect-qrcode-modal@npm:2.0.0"
   dependencies:
-    "@terra-dev/browser-check": ^2.0.0-alpha.2
+    "@terra-dev/browser-check": ^2.0.0
     "@walletconnect/types": ^1.6.1
     qrcode.react: ^1.0.1
     styled-components: ^5.0.0
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: 86b09d24fa00cc80e0713636734b387e843cbe4bdecbc97191dc7d5d99c7b8c10f61ada5d492b453e8e142aa89d4e763c3742be77d36a9abcfd5b2a9688ed7ed
+  checksum: fc95aee7a813dca6845c4261d1f69c809787694a25653655eb965d5eb0b6647d3dabb587beda77cde4135ae69076451ffdf4274e988d4754da217a5aa21e7c7a
   languageName: node
   linkType: hard
 
-"@terra-dev/walletconnect@npm:^2.0.0-alpha.2":
-  version: 2.0.0-alpha.2
-  resolution: "@terra-dev/walletconnect@npm:2.0.0-alpha.2"
+"@terra-dev/walletconnect@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@terra-dev/walletconnect@npm:2.0.0"
   dependencies:
-    "@terra-dev/browser-check": ^2.0.0-alpha.2
-    "@terra-dev/walletconnect-qrcode-modal": ^2.0.0-alpha.2
+    "@terra-dev/browser-check": ^2.0.0
+    "@terra-dev/walletconnect-qrcode-modal": ^2.0.0
     "@terra-money/terra.js": ^1.8.0 || ^2.0.0
     "@walletconnect/core": ^1.6.1
     "@walletconnect/iso-crypto": ^1.6.1
@@ -3134,7 +3134,7 @@ __metadata:
     "@walletconnect/utils": ^1.6.1
     rxjs: ^7.3.0
     ws: ^7.5.3
-  checksum: dbdc8344d44097405c6fc86d65d09bf343d951611f4954516a763e3563b993cb7f54049853fc3cdf047e1870e85d44b16cde28de00006deb142dd83fa06a11bb
+  checksum: 0793f54ebfad276073f65e4da2df3b37377145f48124c9b593e9dcc22a6344575a824ea8ec2524d8382e5fffdeacd54ba3bd94ee44d922ccf1cdc017518a1002
   languageName: node
   linkType: hard
 
@@ -3185,16 +3185,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terra-money/wallet-provider@npm:^2.0.0-alpha.2":
-  version: 2.0.0-alpha.2
-  resolution: "@terra-money/wallet-provider@npm:2.0.0-alpha.2"
+"@terra-money/wallet-provider@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@terra-money/wallet-provider@npm:2.0.0"
   dependencies:
-    "@terra-dev/browser-check": ^2.0.0-alpha.2
-    "@terra-dev/chrome-extension": ^2.0.0-alpha.2
-    "@terra-dev/readonly-wallet": ^2.0.0-alpha.2
-    "@terra-dev/readonly-wallet-modal": ^2.0.0-alpha.2
-    "@terra-dev/wallet-types": ^2.0.0-alpha.2
-    "@terra-dev/walletconnect": ^2.0.0-alpha.2
+    "@terra-dev/browser-check": ^2.0.0
+    "@terra-dev/chrome-extension": ^2.0.0
+    "@terra-dev/readonly-wallet": ^2.0.0
+    "@terra-dev/readonly-wallet-modal": ^2.0.0
+    "@terra-dev/wallet-types": ^2.0.0
+    "@terra-dev/walletconnect": ^2.0.0
     "@terra-dev/web-extension": ^0.5.2
     "@terra-money/terra.js": ^1.8.0 || ^2.0.0
     fast-deep-equal: ^3.1.3
@@ -3204,7 +3204,7 @@ __metadata:
   peerDependenciesMeta:
     react-router-dom:
       optional: true
-  checksum: a37471db60226bb96855db22ff145425ac6f724d5a581cb7a16f949d00a2431a307423b20543610665e9e127372b6d09c28ea9053802895dbc80b1dda7e10716
+  checksum: 5f5891731a5e36db7162d7eb49292cd9a6de09ee5aa6d0b9c3af0bb45f9ddc5ce27bd02752b256278547cc7f0acea36865c290e1d9723b035551f3bf8d6b65fa
   languageName: node
   linkType: hard
 
@@ -6609,7 +6609,7 @@ __metadata:
   resolution: "cra-template@workspace:templates/create-react-app"
   dependencies:
     "@terra-money/terra.js": ^2.0.1
-    "@terra-money/wallet-provider": ^2.0.0-alpha.2
+    "@terra-money/wallet-provider": ^2.0.0
     "@testing-library/jest-dom": ^5.14.1
     "@types/jest": ^26.0.24
     "@types/react": ^17.0.18
@@ -13013,7 +13013,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "next-template@workspace:templates/next"
   dependencies:
-    "@terra-money/wallet-provider": ^2.0.0-alpha.2
+    "@terra-money/wallet-provider": ^2.0.0
     "@types/react": ^17.0.18
     "@types/react-dom": ^17.0.9
     next: ^11.1.0
@@ -18964,7 +18964,7 @@ resolve@^2.0.0-next.3:
   dependencies:
     "@peculiar/webcrypto": ^1.1.7
     "@terra-money/terra.js": ^2.0.1
-    "@terra-money/wallet-provider": ^2.0.0-alpha.2
+    "@terra-money/wallet-provider": ^2.0.0
     "@testing-library/jest-dom": ^5.14.1
     "@types/node": ^16.6.1
     "@types/react": ^17.0.18
@@ -19434,7 +19434,7 @@ resolve@^2.0.0-next.3:
   resolution: "without-react-template@workspace:templates/wallet-controller"
   dependencies:
     "@terra-money/terra.js": ^2.0.1
-    "@terra-money/wallet-provider": ^2.0.0-alpha.2
+    "@terra-money/wallet-provider": ^2.0.0
     "@testing-library/jest-dom": ^5.14.1
     "@types/jest": ^26.0.24
     "@types/react": ^17.0.18

--- a/yarn.lock
+++ b/yarn.lock
@@ -3029,129 +3029,129 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terra-dev/browser-check@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "@terra-dev/browser-check@npm:1.2.4"
+"@terra-dev/browser-check@npm:^2.0.0-alpha.1":
+  version: 2.0.0-alpha.1
+  resolution: "@terra-dev/browser-check@npm:2.0.0-alpha.1"
   dependencies:
     bowser: ^2.11.0
     mobile-detect: ^1.4.5
-  checksum: ce5ac1954acda6b7e85e01259f03d004680a6936da42a6308d7b70f3c19dff14e2af0a076c288686d60aa89c92e335e100cee6a97dca5a3a37306982170962f3
+  checksum: 5e2abb817a5bee9d3b975393d290acd2aca3005bafb216dd9f19a1efd01697161645a2f0410bb27c9c0b55c8a531b4b1d948cb6db8b0464053e16d4a82cbd76d
   languageName: node
   linkType: hard
 
-"@terra-dev/chrome-extension@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "@terra-dev/chrome-extension@npm:1.2.4"
+"@terra-dev/chrome-extension@npm:^2.0.0-alpha.1":
+  version: 2.0.0-alpha.1
+  resolution: "@terra-dev/chrome-extension@npm:2.0.0-alpha.1"
   dependencies:
-    "@terra-dev/browser-check": ^1.2.4
-    "@terra-dev/wallet-types": ^1.2.4
-    "@terra-money/terra.js": ^1.8.0
-    rxjs: ^7.1.0
-  checksum: da982c8d802dac09475d39f7b30d08e11103fc9f738aca0b0e7b6b49f0e42f6ad1d9a13d766da9205f8e377d54677baf029ecd4be1e055e8066e792a078998d3
+    "@terra-dev/browser-check": ^2.0.0-alpha.1
+    "@terra-dev/wallet-types": ^2.0.0-alpha.1
+    "@terra-money/terra.js": ^1.8.0 || ^2.0.0
+    rxjs: ^7.3.0
+  checksum: dcffa437377e5783719d341330a96fff118f0cdeeacfe3a81aa70a5b5378b6c6d455b8c7601673ce021eb0de8c68b0f491a85e94895d4f6510a0f99f35af7a91
   languageName: node
   linkType: hard
 
-"@terra-dev/readonly-wallet-modal@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "@terra-dev/readonly-wallet-modal@npm:1.2.4"
+"@terra-dev/readonly-wallet-modal@npm:^2.0.0-alpha.1":
+  version: 2.0.0-alpha.1
+  resolution: "@terra-dev/readonly-wallet-modal@npm:2.0.0-alpha.1"
   dependencies:
-    "@terra-dev/readonly-wallet": ^1.2.4
-    "@terra-dev/wallet-types": ^1.2.4
-    "@terra-money/terra.js": ^1.8.0
+    "@terra-dev/readonly-wallet": ^2.0.0-alpha.1
+    "@terra-dev/wallet-types": ^2.0.0-alpha.1
+    "@terra-money/terra.js": ^1.8.0 || ^2.0.0
     styled-components: ^5.0.0
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: aed47700e6f11f4a3222ef62e6502134afa4563e29dea55728aeb0d24ee9c296f7436c62fbd911a6f7ebcdae0431f2b59e3f4671474bf9d40e05a4ccae5c9c38
+  checksum: d255b25eed19496572e308db2facdb4a7f731a5d32a29ce4de2c6b6ed803f1c9cc236d066a903eb846856158eaf3ee198ae75123880ed26473ad3a998e6cda9f
   languageName: node
   linkType: hard
 
-"@terra-dev/readonly-wallet@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "@terra-dev/readonly-wallet@npm:1.2.4"
+"@terra-dev/readonly-wallet@npm:^2.0.0-alpha.1":
+  version: 2.0.0-alpha.1
+  resolution: "@terra-dev/readonly-wallet@npm:2.0.0-alpha.1"
   dependencies:
-    "@terra-dev/wallet-types": ^1.2.4
-    "@terra-money/terra.js": ^1.8.0
-  checksum: 2a4e2a82e2c08c46527bedbad112b9a6748e2d7690a50b22c79a7155940d8e8ec3b514c31eda71b7337b61c34587f03898d451ac7adace08cdf152e598c94a3d
+    "@terra-dev/wallet-types": ^2.0.0-alpha.1
+    "@terra-money/terra.js": ^1.8.0 || ^2.0.0
+  checksum: 48d07172299ead0dccdcb3df5ee2c1d5f6b02faa333095c60a3fe1eb49b07f194cdfe6fd0c77d8a9bb5199c0e0c2b871f78512cd271c0fbfbb4419344976b7d9
   languageName: node
   linkType: hard
 
-"@terra-dev/safari-webextension-storage-change-listener@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@terra-dev/safari-webextension-storage-change-listener@npm:0.4.0"
+"@terra-dev/safari-webextension-storage-change-listener@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "@terra-dev/safari-webextension-storage-change-listener@npm:0.5.2"
   dependencies:
     fast-deep-equal: ^3.1.3
     rxjs: ^7.0.0
     webextension-polyfill-ts: ^0.25.0
-  checksum: de718dd73ef5b618d5ae826e1ed09487d46fabcb8bfeee1282af299be738327ea268038f1d2a53c633b950d57c3fc64bab56993c822f5b33c6a4c6426f380b46
+  checksum: dffa4197f67f52a167f04b841e62763b9fb0ed6ec502bf2f7452818725133534d5e76616e9991220dba221683c2737d1fedc50e6db200872bebb181b9bd9625b
   languageName: node
   linkType: hard
 
-"@terra-dev/wallet-types@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "@terra-dev/wallet-types@npm:1.2.4"
+"@terra-dev/wallet-types@npm:^2.0.0-alpha.1":
+  version: 2.0.0-alpha.1
+  resolution: "@terra-dev/wallet-types@npm:2.0.0-alpha.1"
   dependencies:
-    "@terra-money/terra.js": ^1.8.0
-  checksum: e2c767b3d6227b607cbaf215f068c3447c6c51b17cebda35cba29cdf5d4940cd6e10bcc8a84edfaf140f934dfcccf3e63ee1ce1373ae28a80fcec5dcaead8a7a
+    "@terra-money/terra.js": ^1.8.0 || ^2.0.0
+  checksum: a85e02c61bf327083f129c8ca23e92f633ca8d64296c6c4f8138683945dad789a34d6705f1128dfcd541cfbfa190dad5e364c56d74e660de275006cda5f66cbd
   languageName: node
   linkType: hard
 
-"@terra-dev/wallet@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@terra-dev/wallet@npm:0.4.0"
+"@terra-dev/wallet@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "@terra-dev/wallet@npm:0.5.2"
   dependencies:
     "@terra-money/key-utils": ^1.0.2
-    "@terra-money/terra.js": ^1.7.0
-  checksum: 8b248e0c4ab283b697b9699a15dedc36dd0ba45122016b7d21123b2894745324e6fd410883721b18f887febda6f20d48ad661520b929a5ab5f69f06ce6106fe2
+    "@terra-money/terra.js": ^1.8.0 || ^2.0.0
+  checksum: 1fe8581bb75f025835ef1a87585188af08aa0b579c9751c187caa815e3a1ac2330693d1de4bf27610e2cdeebce25fd5d12a30e2b1ddab0c7d4a456ec02d27d7a
   languageName: node
   linkType: hard
 
-"@terra-dev/walletconnect-qrcode-modal@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "@terra-dev/walletconnect-qrcode-modal@npm:1.2.4"
+"@terra-dev/walletconnect-qrcode-modal@npm:^2.0.0-alpha.1":
+  version: 2.0.0-alpha.1
+  resolution: "@terra-dev/walletconnect-qrcode-modal@npm:2.0.0-alpha.1"
   dependencies:
-    "@terra-dev/browser-check": ^1.2.4
-    "@walletconnect/types": ^1.4.1
+    "@terra-dev/browser-check": ^2.0.0-alpha.1
+    "@walletconnect/types": ^1.6.1
     qrcode.react: ^1.0.1
     styled-components: ^5.0.0
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: 90e2a1060ff8e9c9019513bba1889f7f388f9b315e1fd5e51e3945d2635f2269364fb7774ae867489d87f1cbcecc08eb0a78b39c14b877824b6acf3e074fa3c3
+  checksum: b767f64ec31b212fd0bf54a5032cd9879ec027b0a3ee259275a67efce94a3cf399dd5de36cf9a05380e0d68c65899f5a3bcf0151c9841f1d1173365e693f314f
   languageName: node
   linkType: hard
 
-"@terra-dev/walletconnect@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "@terra-dev/walletconnect@npm:1.2.4"
+"@terra-dev/walletconnect@npm:^2.0.0-alpha.1":
+  version: 2.0.0-alpha.1
+  resolution: "@terra-dev/walletconnect@npm:2.0.0-alpha.1"
   dependencies:
-    "@terra-dev/browser-check": ^1.2.4
-    "@terra-dev/walletconnect-qrcode-modal": ^1.2.4
-    "@terra-money/terra.js": ^1.8.0
-    "@walletconnect/core": ^1.4.1
-    "@walletconnect/iso-crypto": ^1.4.1
-    "@walletconnect/types": ^1.4.1
-    "@walletconnect/utils": ^1.4.1
-    rxjs: ^7.1.0
-    ws: ^7.4.6
-  checksum: 0346b327d37f834f44fa3651bde05315b3a392b0a2d18d48ccc9ee4108cc167713ec23aef05cab7a313dfa54f6064307d53805e64a996101efcdfff9bdf4d924
+    "@terra-dev/browser-check": ^2.0.0-alpha.1
+    "@terra-dev/walletconnect-qrcode-modal": ^2.0.0-alpha.1
+    "@terra-money/terra.js": ^1.8.0 || ^2.0.0
+    "@walletconnect/core": ^1.6.1
+    "@walletconnect/iso-crypto": ^1.6.1
+    "@walletconnect/types": ^1.6.1
+    "@walletconnect/utils": ^1.6.1
+    rxjs: ^7.3.0
+    ws: ^7.5.3
+  checksum: 432c623e892282f0f09a7428a672b5c98f31ecacbb785f6694b583fd6ef61a2c867afd82bcb7a9d54798f73bd998e99f79a1796a3dd280d00caf45e63a415e4d
   languageName: node
   linkType: hard
 
-"@terra-dev/web-extension@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@terra-dev/web-extension@npm:0.4.0"
+"@terra-dev/web-extension@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "@terra-dev/web-extension@npm:0.5.2"
   dependencies:
-    "@terra-dev/safari-webextension-storage-change-listener": ^0.4.0
-    "@terra-dev/wallet": ^0.4.0
+    "@terra-dev/safari-webextension-storage-change-listener": ^0.5.2
+    "@terra-dev/wallet": ^0.5.2
     "@terra-money/key-utils": ^1.0.2
-    "@terra-money/terra.js": ^1.7.0
+    "@terra-money/terra.js": ^1.8.0 || ^2.0.0
     bowser: ^2.11.0
     post-message-stream: ^3.0.0
     react: ^17.0.2
     rxjs: ^7.0.0
     webextension-polyfill-ts: ^0.25.0
-  checksum: 2db7b5acab20d161868497f6f92afc7632b5da8122b2b973eb7e97f858cce22dc07c156779d5293e6c97251475ddbcc734d4647488dc0856d2ef70b28083122f
+  checksum: 87c9815e5bccf3658515d267faeec85b10d4bd2434d8af1559b9383e49ddf12594ff519e0f6a1890fa2574d8835ca212ed0dc5b13e3ef11965dce78cb8b8b99b
   languageName: node
   linkType: hard
 
@@ -3165,9 +3165,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terra-money/terra.js@npm:^1.7.0, @terra-money/terra.js@npm:^1.8.0, @terra-money/terra.js@npm:^1.8.9":
-  version: 1.8.9
-  resolution: "@terra-money/terra.js@npm:1.8.9"
+"@terra-money/terra.js@npm:^1.8.0 || ^2.0.0, @terra-money/terra.js@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@terra-money/terra.js@npm:2.0.1"
   dependencies:
     axios: ^0.21.1
     bech32: ^2.0.0
@@ -3181,30 +3181,30 @@ __metadata:
     tmp: ^0.2.1
     utf-8-validate: ^5.0.5
     ws: ^7.4.2
-  checksum: 277a8e5746f7be8f5bd3f46fc5930c0305c1532c5c74fb923a3748a05a271b0dfc1b004ee7540fc715744fb56cc82d1c74246444ab68b68ab040d057036ddc51
+  checksum: 33766fc13d55eb9cc5203aec0acee7ffb639c5fe67ba9e58526725f6fa88a5c33f360633e0ce6bcc806da4f1986e6fc60736236a57410ee995aa4feaef439fd0
   languageName: node
   linkType: hard
 
-"@terra-money/wallet-provider@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "@terra-money/wallet-provider@npm:1.2.4"
+"@terra-money/wallet-provider@npm:^2.0.0-alpha.1":
+  version: 2.0.0-alpha.1
+  resolution: "@terra-money/wallet-provider@npm:2.0.0-alpha.1"
   dependencies:
-    "@terra-dev/browser-check": ^1.2.4
-    "@terra-dev/chrome-extension": ^1.2.4
-    "@terra-dev/readonly-wallet": ^1.2.4
-    "@terra-dev/readonly-wallet-modal": ^1.2.4
-    "@terra-dev/wallet-types": ^1.2.4
-    "@terra-dev/walletconnect": ^1.2.4
-    "@terra-dev/web-extension": ^0.4.0
-    "@terra-money/terra.js": ^1.8.0
+    "@terra-dev/browser-check": ^2.0.0-alpha.1
+    "@terra-dev/chrome-extension": ^2.0.0-alpha.1
+    "@terra-dev/readonly-wallet": ^2.0.0-alpha.1
+    "@terra-dev/readonly-wallet-modal": ^2.0.0-alpha.1
+    "@terra-dev/wallet-types": ^2.0.0-alpha.1
+    "@terra-dev/walletconnect": ^2.0.0-alpha.1
+    "@terra-dev/web-extension": ^0.5.2
+    "@terra-money/terra.js": ^1.8.0 || ^2.0.0
     fast-deep-equal: ^3.1.3
-    rxjs: ^7.1.0
+    rxjs: ^7.3.0
   peerDependencies:
     react: ^17.0.0
   peerDependenciesMeta:
     react-router-dom:
       optional: true
-  checksum: 6e63acd06b01291b7c834a0f836e9619002d76bc9a0c2c96797fdc0608d245a10ac7dec86dfea795a8bead76892800d4b4db99fb5ff1d8594ccfd79fd9219279
+  checksum: f009dabff679997c153e39d4029a468c836067ab38a03da33a5d5f11c8364f8972fd4308fd8ebd63419ead8140ba47b3a3c94dc236423d1f1e077e900ce72a6b
   languageName: node
   linkType: hard
 
@@ -3953,7 +3953,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/core@npm:^1.4.1, @walletconnect/core@npm:^1.6.1":
+"@walletconnect/core@npm:^1.6.1":
   version: 1.6.1
   resolution: "@walletconnect/core@npm:1.6.1"
   dependencies:
@@ -3994,7 +3994,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/iso-crypto@npm:^1.4.1, @walletconnect/iso-crypto@npm:^1.6.1":
+"@walletconnect/iso-crypto@npm:^1.6.1":
   version: 1.6.1
   resolution: "@walletconnect/iso-crypto@npm:1.6.1"
   dependencies:
@@ -4053,14 +4053,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@walletconnect/types@npm:^1.4.1, @walletconnect/types@npm:^1.6.1":
+"@walletconnect/types@npm:^1.6.1":
   version: 1.6.1
   resolution: "@walletconnect/types@npm:1.6.1"
   checksum: 686efb470914573be5dbfdd2546bd85ec70c28356dcd9fb61125309c83a795d1b42fd22f5dadb8cbc800f6d820dc2de899b0210c3bfd0949f1a1929ef2221385
   languageName: node
   linkType: hard
 
-"@walletconnect/utils@npm:^1.4.1, @walletconnect/utils@npm:^1.6.1":
+"@walletconnect/utils@npm:^1.6.1":
   version: 1.6.1
   resolution: "@walletconnect/utils@npm:1.6.1"
   dependencies:
@@ -6608,8 +6608,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "cra-template@workspace:templates/create-react-app"
   dependencies:
-    "@terra-money/terra.js": ^1.8.9
-    "@terra-money/wallet-provider": ^1.2.4
+    "@terra-money/terra.js": ^2.0.1
+    "@terra-money/wallet-provider": ^2.0.0-alpha.1
     "@testing-library/jest-dom": ^5.14.1
     "@types/jest": ^26.0.24
     "@types/react": ^17.0.18
@@ -13013,7 +13013,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "next-template@workspace:templates/next"
   dependencies:
-    "@terra-money/wallet-provider": ^1.2.4
+    "@terra-money/wallet-provider": ^2.0.0-alpha.1
     "@types/react": ^17.0.18
     "@types/react-dom": ^17.0.9
     next: ^11.1.0
@@ -13746,8 +13746,8 @@ fsevents@^1.2.7:
   dependencies:
     "@sentry/browser": ^6.11.0
     "@sentry/tracing": ^6.11.0
-    "@terra-dev/web-extension": ^0.4.0
-    "@terra-money/terra.js": ^1.8.9
+    "@terra-dev/web-extension": ^0.5.2
+    "@terra-money/terra.js": ^2.0.1
     "@testing-library/jest-dom": ^5.14.1
     "@types/jest": ^26.0.24
     "@types/puppeteer": ^5.4.4
@@ -16502,7 +16502,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.0.0, rxjs@npm:^7.1.0, rxjs@npm:^7.3.0":
+"rxjs@npm:^7.0.0, rxjs@npm:^7.3.0":
   version: 7.3.0
   resolution: "rxjs@npm:7.3.0"
   dependencies:
@@ -18952,8 +18952,8 @@ resolve@^2.0.0-next.3:
   resolution: "vite-template@workspace:templates/vite"
   dependencies:
     "@peculiar/webcrypto": ^1.1.7
-    "@terra-money/terra.js": ^1.8.9
-    "@terra-money/wallet-provider": ^1.2.4
+    "@terra-money/terra.js": ^2.0.1
+    "@terra-money/wallet-provider": ^2.0.0-alpha.1
     "@testing-library/jest-dom": ^5.14.1
     "@types/node": ^16.6.1
     "@types/react": ^17.0.18
@@ -19421,8 +19421,8 @@ resolve@^2.0.0-next.3:
   version: 0.0.0-use.local
   resolution: "without-react-template@workspace:templates/wallet-controller"
   dependencies:
-    "@terra-money/terra.js": ^1.8.9
-    "@terra-money/wallet-provider": ^1.2.4
+    "@terra-money/terra.js": ^2.0.1
+    "@terra-money/wallet-provider": ^2.0.0-alpha.1
     "@testing-library/jest-dom": ^5.14.1
     "@types/jest": ^26.0.24
     "@types/react": ^17.0.18
@@ -19715,7 +19715,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"ws@npm:7.5.3, ws@npm:^7.4.2, ws@npm:^7.4.5, ws@npm:^7.4.6, ws@npm:^7.5.3":
+"ws@npm:7.5.3, ws@npm:^7.4.2, ws@npm:^7.4.5, ws@npm:^7.5.3":
   version: 7.5.3
   resolution: "ws@npm:7.5.3"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3029,50 +3029,50 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terra-dev/browser-check@npm:^2.0.0-alpha.1":
-  version: 2.0.0-alpha.1
-  resolution: "@terra-dev/browser-check@npm:2.0.0-alpha.1"
+"@terra-dev/browser-check@npm:^2.0.0-alpha.2":
+  version: 2.0.0-alpha.2
+  resolution: "@terra-dev/browser-check@npm:2.0.0-alpha.2"
   dependencies:
     bowser: ^2.11.0
     mobile-detect: ^1.4.5
-  checksum: 5e2abb817a5bee9d3b975393d290acd2aca3005bafb216dd9f19a1efd01697161645a2f0410bb27c9c0b55c8a531b4b1d948cb6db8b0464053e16d4a82cbd76d
+  checksum: f6cff8dfaf3615da534100c553377f50da7aa62617f44f0280a3ede0922f88fb8dc4af30e4e436e68a807c29a42052c1f3b1f15a5c6b0888b47d6d6061d11959
   languageName: node
   linkType: hard
 
-"@terra-dev/chrome-extension@npm:^2.0.0-alpha.1":
-  version: 2.0.0-alpha.1
-  resolution: "@terra-dev/chrome-extension@npm:2.0.0-alpha.1"
+"@terra-dev/chrome-extension@npm:^2.0.0-alpha.2":
+  version: 2.0.0-alpha.2
+  resolution: "@terra-dev/chrome-extension@npm:2.0.0-alpha.2"
   dependencies:
-    "@terra-dev/browser-check": ^2.0.0-alpha.1
-    "@terra-dev/wallet-types": ^2.0.0-alpha.1
+    "@terra-dev/browser-check": ^2.0.0-alpha.2
+    "@terra-dev/wallet-types": ^2.0.0-alpha.2
     "@terra-money/terra.js": ^1.8.0 || ^2.0.0
     rxjs: ^7.3.0
-  checksum: dcffa437377e5783719d341330a96fff118f0cdeeacfe3a81aa70a5b5378b6c6d455b8c7601673ce021eb0de8c68b0f491a85e94895d4f6510a0f99f35af7a91
+  checksum: cdff547f6361f4ddaca5850e6d98e70965afad2a4d07a63b6a0911d20ff34de1bde8647b7e846b4e0592c2aca132c5308dbc44954ecbb4def496039f7074bc8c
   languageName: node
   linkType: hard
 
-"@terra-dev/readonly-wallet-modal@npm:^2.0.0-alpha.1":
-  version: 2.0.0-alpha.1
-  resolution: "@terra-dev/readonly-wallet-modal@npm:2.0.0-alpha.1"
+"@terra-dev/readonly-wallet-modal@npm:^2.0.0-alpha.2":
+  version: 2.0.0-alpha.2
+  resolution: "@terra-dev/readonly-wallet-modal@npm:2.0.0-alpha.2"
   dependencies:
-    "@terra-dev/readonly-wallet": ^2.0.0-alpha.1
-    "@terra-dev/wallet-types": ^2.0.0-alpha.1
+    "@terra-dev/readonly-wallet": ^2.0.0-alpha.2
+    "@terra-dev/wallet-types": ^2.0.0-alpha.2
     "@terra-money/terra.js": ^1.8.0 || ^2.0.0
     styled-components: ^5.0.0
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: d255b25eed19496572e308db2facdb4a7f731a5d32a29ce4de2c6b6ed803f1c9cc236d066a903eb846856158eaf3ee198ae75123880ed26473ad3a998e6cda9f
+  checksum: dd6e687d68d48c7293b8c2274a53ab6775a05f252b9acdc1c774847fb138a876cb2543128982bfc9a7c4da502d80df5e84246b378eb3cc717252c768092302ac
   languageName: node
   linkType: hard
 
-"@terra-dev/readonly-wallet@npm:^2.0.0-alpha.1":
-  version: 2.0.0-alpha.1
-  resolution: "@terra-dev/readonly-wallet@npm:2.0.0-alpha.1"
+"@terra-dev/readonly-wallet@npm:^2.0.0-alpha.2":
+  version: 2.0.0-alpha.2
+  resolution: "@terra-dev/readonly-wallet@npm:2.0.0-alpha.2"
   dependencies:
-    "@terra-dev/wallet-types": ^2.0.0-alpha.1
+    "@terra-dev/wallet-types": ^2.0.0-alpha.2
     "@terra-money/terra.js": ^1.8.0 || ^2.0.0
-  checksum: 48d07172299ead0dccdcb3df5ee2c1d5f6b02faa333095c60a3fe1eb49b07f194cdfe6fd0c77d8a9bb5199c0e0c2b871f78512cd271c0fbfbb4419344976b7d9
+  checksum: 660d5582d46463d1cb3d1bede194ebf5a23067200ced884fd7130d945a8258d9aed6053b813d3e9509d5f9ac40792f1633d176e1b47f9ea4debded8b07f7bf65
   languageName: node
   linkType: hard
 
@@ -3087,12 +3087,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terra-dev/wallet-types@npm:^2.0.0-alpha.1":
-  version: 2.0.0-alpha.1
-  resolution: "@terra-dev/wallet-types@npm:2.0.0-alpha.1"
+"@terra-dev/wallet-types@npm:^2.0.0-alpha.2":
+  version: 2.0.0-alpha.2
+  resolution: "@terra-dev/wallet-types@npm:2.0.0-alpha.2"
   dependencies:
     "@terra-money/terra.js": ^1.8.0 || ^2.0.0
-  checksum: a85e02c61bf327083f129c8ca23e92f633ca8d64296c6c4f8138683945dad789a34d6705f1128dfcd541cfbfa190dad5e364c56d74e660de275006cda5f66cbd
+  checksum: 83fae2c50f90c6daf11f0ca3ebfead444b01e3a19fd593e56d3dc33f814683e96729ff1c6bb69c33eb820cb43d384efa527a549294c6a7400ace72cb6c8d2d6e
   languageName: node
   linkType: hard
 
@@ -3106,27 +3106,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terra-dev/walletconnect-qrcode-modal@npm:^2.0.0-alpha.1":
-  version: 2.0.0-alpha.1
-  resolution: "@terra-dev/walletconnect-qrcode-modal@npm:2.0.0-alpha.1"
+"@terra-dev/walletconnect-qrcode-modal@npm:^2.0.0-alpha.2":
+  version: 2.0.0-alpha.2
+  resolution: "@terra-dev/walletconnect-qrcode-modal@npm:2.0.0-alpha.2"
   dependencies:
-    "@terra-dev/browser-check": ^2.0.0-alpha.1
+    "@terra-dev/browser-check": ^2.0.0-alpha.2
     "@walletconnect/types": ^1.6.1
     qrcode.react: ^1.0.1
     styled-components: ^5.0.0
   peerDependencies:
     react: ^17.0.0
     react-dom: ^17.0.0
-  checksum: b767f64ec31b212fd0bf54a5032cd9879ec027b0a3ee259275a67efce94a3cf399dd5de36cf9a05380e0d68c65899f5a3bcf0151c9841f1d1173365e693f314f
+  checksum: 86b09d24fa00cc80e0713636734b387e843cbe4bdecbc97191dc7d5d99c7b8c10f61ada5d492b453e8e142aa89d4e763c3742be77d36a9abcfd5b2a9688ed7ed
   languageName: node
   linkType: hard
 
-"@terra-dev/walletconnect@npm:^2.0.0-alpha.1":
-  version: 2.0.0-alpha.1
-  resolution: "@terra-dev/walletconnect@npm:2.0.0-alpha.1"
+"@terra-dev/walletconnect@npm:^2.0.0-alpha.2":
+  version: 2.0.0-alpha.2
+  resolution: "@terra-dev/walletconnect@npm:2.0.0-alpha.2"
   dependencies:
-    "@terra-dev/browser-check": ^2.0.0-alpha.1
-    "@terra-dev/walletconnect-qrcode-modal": ^2.0.0-alpha.1
+    "@terra-dev/browser-check": ^2.0.0-alpha.2
+    "@terra-dev/walletconnect-qrcode-modal": ^2.0.0-alpha.2
     "@terra-money/terra.js": ^1.8.0 || ^2.0.0
     "@walletconnect/core": ^1.6.1
     "@walletconnect/iso-crypto": ^1.6.1
@@ -3134,7 +3134,7 @@ __metadata:
     "@walletconnect/utils": ^1.6.1
     rxjs: ^7.3.0
     ws: ^7.5.3
-  checksum: 432c623e892282f0f09a7428a672b5c98f31ecacbb785f6694b583fd6ef61a2c867afd82bcb7a9d54798f73bd998e99f79a1796a3dd280d00caf45e63a415e4d
+  checksum: dbdc8344d44097405c6fc86d65d09bf343d951611f4954516a763e3563b993cb7f54049853fc3cdf047e1870e85d44b16cde28de00006deb142dd83fa06a11bb
   languageName: node
   linkType: hard
 
@@ -3185,16 +3185,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terra-money/wallet-provider@npm:^2.0.0-alpha.1":
-  version: 2.0.0-alpha.1
-  resolution: "@terra-money/wallet-provider@npm:2.0.0-alpha.1"
+"@terra-money/wallet-provider@npm:^2.0.0-alpha.2":
+  version: 2.0.0-alpha.2
+  resolution: "@terra-money/wallet-provider@npm:2.0.0-alpha.2"
   dependencies:
-    "@terra-dev/browser-check": ^2.0.0-alpha.1
-    "@terra-dev/chrome-extension": ^2.0.0-alpha.1
-    "@terra-dev/readonly-wallet": ^2.0.0-alpha.1
-    "@terra-dev/readonly-wallet-modal": ^2.0.0-alpha.1
-    "@terra-dev/wallet-types": ^2.0.0-alpha.1
-    "@terra-dev/walletconnect": ^2.0.0-alpha.1
+    "@terra-dev/browser-check": ^2.0.0-alpha.2
+    "@terra-dev/chrome-extension": ^2.0.0-alpha.2
+    "@terra-dev/readonly-wallet": ^2.0.0-alpha.2
+    "@terra-dev/readonly-wallet-modal": ^2.0.0-alpha.2
+    "@terra-dev/wallet-types": ^2.0.0-alpha.2
+    "@terra-dev/walletconnect": ^2.0.0-alpha.2
     "@terra-dev/web-extension": ^0.5.2
     "@terra-money/terra.js": ^1.8.0 || ^2.0.0
     fast-deep-equal: ^3.1.3
@@ -3204,7 +3204,7 @@ __metadata:
   peerDependenciesMeta:
     react-router-dom:
       optional: true
-  checksum: f009dabff679997c153e39d4029a468c836067ab38a03da33a5d5f11c8364f8972fd4308fd8ebd63419ead8140ba47b3a3c94dc236423d1f1e077e900ce72a6b
+  checksum: a37471db60226bb96855db22ff145425ac6f724d5a581cb7a16f949d00a2431a307423b20543610665e9e127372b6d09c28ea9053802895dbc80b1dda7e10716
   languageName: node
   linkType: hard
 
@@ -6609,7 +6609,7 @@ __metadata:
   resolution: "cra-template@workspace:templates/create-react-app"
   dependencies:
     "@terra-money/terra.js": ^2.0.1
-    "@terra-money/wallet-provider": ^2.0.0-alpha.1
+    "@terra-money/wallet-provider": ^2.0.0-alpha.2
     "@testing-library/jest-dom": ^5.14.1
     "@types/jest": ^26.0.24
     "@types/react": ^17.0.18
@@ -13013,7 +13013,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "next-template@workspace:templates/next"
   dependencies:
-    "@terra-money/wallet-provider": ^2.0.0-alpha.1
+    "@terra-money/wallet-provider": ^2.0.0-alpha.2
     "@types/react": ^17.0.18
     "@types/react-dom": ^17.0.9
     next: ^11.1.0
@@ -18936,6 +18936,17 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"vite-compatible-readable-stream@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "vite-compatible-readable-stream@npm:3.6.0"
+  dependencies:
+    inherits: ^2.0.3
+    string_decoder: ^1.1.1
+    util-deprecate: ^1.0.1
+  checksum: a2875806c268e9e79417c0218a3c61778e8d8bc99c95164a5c83b2400af4b6b6ac3a30c892cb3e9a9c2dc8932d44146b7f56f5679a3b272aa8f82e35d8667584
+  languageName: node
+  linkType: hard
+
 "vite-plugin-svgr@npm:^0.4.0":
   version: 0.4.0
   resolution: "vite-plugin-svgr@npm:0.4.0"
@@ -18953,7 +18964,7 @@ resolve@^2.0.0-next.3:
   dependencies:
     "@peculiar/webcrypto": ^1.1.7
     "@terra-money/terra.js": ^2.0.1
-    "@terra-money/wallet-provider": ^2.0.0-alpha.1
+    "@terra-money/wallet-provider": ^2.0.0-alpha.2
     "@testing-library/jest-dom": ^5.14.1
     "@types/node": ^16.6.1
     "@types/react": ^17.0.18
@@ -18971,6 +18982,7 @@ resolve@^2.0.0-next.3:
     react-scripts: ^4.0.3
     typescript: ^4.3.5
     vite: ^2.5.0
+    vite-compatible-readable-stream: ^3.6.0
     vite-plugin-svgr: ^0.4.0
     vite-tsconfig-paths: ^3.3.13
   languageName: unknown
@@ -19422,7 +19434,7 @@ resolve@^2.0.0-next.3:
   resolution: "without-react-template@workspace:templates/wallet-controller"
   dependencies:
     "@terra-money/terra.js": ^2.0.1
-    "@terra-money/wallet-provider": ^2.0.0-alpha.1
+    "@terra-money/wallet-provider": ^2.0.0-alpha.2
     "@testing-library/jest-dom": ^5.14.1
     "@types/jest": ^26.0.24
     "@types/react": ^17.0.18


### PR DESCRIPTION
# TODO

- [x] Update `terra.js` to `^1.8.0 || ^2.0.0`
- [x] Basic SendMsg Tx test
  - [x] tequila
  - [x] bombay
- [x] Test connect with Station Mobile ( set network 1 to bombay )
- [x] Test on Anchor WebApp with `terra.js@1.8.x`
- [x] Update `terra.js` of `@anchor-protocol/anchor.js` to `^2.0.0` (or `^1.8.0 || ^2.0.0`)
- [x] Test on Anchor WebApp with `terra.js@2.x`