### PR TITLE
Add BitKeep Wallet to support Terra Dapps

### DIFF
--- a/packages/src/@terra-dev/browser-check/README.md
+++ b/packages/src/@terra-dev/browser-check/README.md
@@ -17,6 +17,10 @@ export function isMathWallet(userAgent: string) {
   return /MathWallet\//.test(userAgent);
 }
 
+export function isBitKeep(userAgent: string) {
+  return /BitKeep\//.test(userAgent);
+}
+
 export const isMobile = () => {
   const mobileDetect = new MobileDetect(navigator.userAgent);
 

--- a/packages/src/@terra-dev/browser-check/index.ts
+++ b/packages/src/@terra-dev/browser-check/index.ts
@@ -8,6 +8,10 @@ export function isMathWallet(userAgent: string) {
   return /MathWallet\//.test(userAgent);
 }
 
+export function isBitKeep(userAgent: string) {
+  return /BitKeep\//.test(userAgent);
+}
+
 export const isMobile = () => {
   const mobileDetect = new MobileDetect(navigator.userAgent);
 


### PR DESCRIPTION
Hi, This is BitKeep Wallet.

BitKeep Wallet has already support LUNA and Terra Dapps eco.
You can test it in our app.

Our website: https://bitkeep.com