### PR TITLE
feat: signBytes(Buffer)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "prettier": "^2.3.2"
   },
   "resolutions": {
-    "@terra-money/terra.js": "2.0.11"
+    "@terra-money/terra.js": "2.0.15"
   }
 }

--- a/packages/.packages.json
+++ b/packages/.packages.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://rocket-hangar.github.io/rocket-punch/schemas/packages.json",
   "@terra-dev/*": {
-    "version": "2.3.0",
-    "tag": "latest"
+    "version": "2.4.0-alpha.1",
+    "tag": "next"
   },
   "@terra-money/*": {
-    "version": "2.3.0",
-    "tag": "latest"
+    "version": "2.4.0-alpha.1",
+    "tag": "next"
   }
 }

--- a/packages/package.json
+++ b/packages/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@terra-dev/web-connector-controller": "^0.7.0",
     "@terra-dev/web-connector-interface": "^0.7.0",
-    "@terra-money/terra.js": "^2.0.1",
+    "@terra-money/terra.js": "^2.0.15",
     "@walletconnect/core": "^1.6.1",
     "@walletconnect/iso-crypto": "^1.6.1",
     "@walletconnect/types": "^1.6.1",

--- a/packages/src/@terra-dev/chrome-extension/ChromeExtensionController.ts
+++ b/packages/src/@terra-dev/chrome-extension/ChromeExtensionController.ts
@@ -176,6 +176,12 @@ export class ChromeExtensionController {
   ): Promise<{ name: string; payload: Payload }> => {
     return this._extension.sign(data);
   };
+
+  signBytes = <Payload extends {}>(
+    bytes: Buffer,
+  ): Promise<{ name: string; payload: Payload }> => {
+    return this._extension.signBytes(bytes);
+  };
 }
 
 async function intervalCheck(

--- a/packages/src/@terra-dev/use-wallet/useConnectedWallet.ts
+++ b/packages/src/@terra-dev/use-wallet/useConnectedWallet.ts
@@ -1,4 +1,8 @@
-import { NetworkInfo, SignResult } from '@terra-dev/wallet-types';
+import {
+  NetworkInfo,
+  SignBytesResult,
+  SignResult,
+} from '@terra-dev/wallet-types';
 import { AccAddress, CreateTxOptions } from '@terra-money/terra.js';
 import { useMemo } from 'react';
 import { TxResult } from './tx';
@@ -14,13 +18,15 @@ export interface ConnectedWallet {
   design?: string;
   post: (tx: CreateTxOptions) => Promise<TxResult>;
   sign: (tx: CreateTxOptions) => Promise<SignResult>;
+  signBytes: (bytes: Buffer) => Promise<SignBytesResult>;
   availablePost: boolean;
   availableSign: boolean;
+  availableSignBytes: boolean;
   connectType: ConnectType;
 }
 
 export function useConnectedWallet(): ConnectedWallet | undefined {
-  const { status, network, wallets, post, sign } = useWallet();
+  const { status, network, wallets, post, sign, signBytes } = useWallet();
 
   const value = useMemo<ConnectedWallet | undefined>(() => {
     try {
@@ -42,11 +48,15 @@ export function useConnectedWallet(): ConnectedWallet | undefined {
           sign: (tx: CreateTxOptions) => {
             return sign(tx, { terraAddress });
           },
+          signBytes: (bytes: Buffer) => {
+            return signBytes(bytes, { terraAddress });
+          },
           availablePost:
             connectType === ConnectType.WEB_CONNECT ||
             connectType === ConnectType.CHROME_EXTENSION ||
             connectType === ConnectType.WALLETCONNECT,
           availableSign: connectType === ConnectType.CHROME_EXTENSION,
+          availableSignBytes: connectType === ConnectType.CHROME_EXTENSION,
           connectType,
         };
       } else {
@@ -55,7 +65,7 @@ export function useConnectedWallet(): ConnectedWallet | undefined {
     } catch {
       return undefined;
     }
-  }, [network, post, sign, status, wallets]);
+  }, [network, post, sign, signBytes, status, wallets]);
 
   return value;
 }

--- a/packages/src/@terra-dev/use-wallet/useWallet.ts
+++ b/packages/src/@terra-dev/use-wallet/useWallet.ts
@@ -1,4 +1,8 @@
-import { NetworkInfo, SignResult } from '@terra-dev/wallet-types';
+import {
+  NetworkInfo,
+  SignBytesResult,
+  SignResult,
+} from '@terra-dev/wallet-types';
 import { CreateTxOptions } from '@terra-money/terra.js';
 import { Consumer, Context, createContext, useContext } from 'react';
 import { TxResult } from './tx';
@@ -226,6 +230,15 @@ export interface Wallet {
     tx: CreateTxOptions,
     txTarget?: { terraAddress?: string },
   ) => Promise<SignResult>;
+
+  /**
+   * TODO
+   * @param bytes
+   */
+  signBytes: (
+    bytes: Buffer,
+    txTarget?: { terraAddress?: string },
+  ) => Promise<SignBytesResult>;
 
   /**
    * Some mobile wallet emulates the behavior of chrome extension.

--- a/packages/src/@terra-dev/wallet-types/types.ts
+++ b/packages/src/@terra-dev/wallet-types/types.ts
@@ -29,3 +29,13 @@ export interface SignResult extends CreateTxOptions {
   };
   success: boolean;
 }
+
+export interface SignBytesResult {
+  encryptedBytes: string;
+  result: {
+    public_key: PublicKey.Data;
+    recid: string;
+    signature: string;
+  };
+  success: boolean;
+}

--- a/packages/src/@terra-money/wallet-provider/controller.ts
+++ b/packages/src/@terra-money/wallet-provider/controller.ts
@@ -664,7 +664,7 @@ export class WalletController {
     interface SignBytesResultRaw {
       bytes: string;
       result: {
-        public_key: PublicKey.Data;
+        public_key: string | PublicKey.Data;
         recid: string;
         signature: string;
       };
@@ -679,8 +679,22 @@ export class WalletController {
       return this.chromeExtension
         .signBytes<SignBytesResultRaw>(bytes)
         .then(({ payload }) => {
+          const publicKey: PublicKey.Data =
+            typeof payload.result.public_key === 'string'
+              ? {
+                  type: 'tendermint/PubKeySecp256k1',
+                  value: payload.result.public_key,
+                }
+              : payload.result.public_key;
+
+          const signBytesResult: SignBytesResult['result'] = {
+            ...payload.result,
+            public_key: publicKey,
+          };
+
           return {
             ...payload,
+            result: signBytesResult,
             encryptedBytes: payload.bytes,
           };
         });

--- a/packages/src/@terra-money/wallet-provider/controller.ts
+++ b/packages/src/@terra-money/wallet-provider/controller.ts
@@ -10,6 +10,7 @@ import {
 import {
   CreateTxFailed,
   NetworkInfo,
+  SignBytesResult,
   SignResult,
   Timeout,
   TxFailed,
@@ -652,6 +653,54 @@ export class WalletController {
 
     throw new Error(`sign() method only available on chrome extension`);
     // TODO implements sign() to other connect types
+  };
+
+  /** @see Wallet#signBytes */
+  signBytes = async (
+    bytes: Buffer,
+    // TODO not work at this time. for the future extension
+    txTarget: { terraAddress?: string } = {},
+  ): Promise<SignBytesResult> => {
+    interface SignBytesResultRaw {
+      bytes: string;
+      result: {
+        public_key: PublicKey.Data;
+        recid: string;
+        signature: string;
+      };
+      success: boolean;
+    }
+
+    if (this.disableChromeExtension) {
+      if (!this.chromeExtension) {
+        throw new Error(`chromeExtension instance not created!`);
+      }
+
+      return this.chromeExtension
+        .signBytes<SignBytesResultRaw>(bytes)
+        .then(({ payload }) => {
+          return {
+            ...payload,
+            encryptedBytes: payload.bytes,
+          };
+        });
+      //.catch((error) => {
+      //  // TODO more detailed errors
+      //  if (error instanceof ChromeExtensionCreateTxFailed) {
+      //    throw new CreateTxFailed({} as any, error.message);
+      //  } else if (error instanceof ChromeExtensionTxFailed) {
+      //    throw new TxFailed({} as any, error.txhash, error.message, null);
+      //  } else if (error instanceof ChromeExtensionUnspecifiedError) {
+      //    throw new TxUnspecifiedError({} as any, error.message);
+      //  }
+      //  // UserDenied - chrome extension will sent original UserDenied error type
+      //  // All unspecified errors...
+      //  throw error;
+      //});
+    }
+
+    throw new Error(`signBytes() method only available on chrome extension`);
+    // TODO implements signBytes() to other connect types
   };
 
   // ================================================================

--- a/packages/src/@terra-money/wallet-provider/react/ExtensionNetworkOnlyWalletProvider.tsx
+++ b/packages/src/@terra-money/wallet-provider/react/ExtensionNetworkOnlyWalletProvider.tsx
@@ -64,6 +64,11 @@ export function ExtensionNetworkOnlyWalletProvider({
           `<ExtensionNetworkOnlyWalletProvider> does not support sign()`,
         );
       },
+      signBytes: () => {
+        throw new Error(
+          `<ExtensionNetworkOnlyWalletProvider> does not support signBytes()`,
+        );
+      },
       recheckStatus: controller.recheckStatus,
       isChromeExtensionCompatibleBrowser: () => {
         throw new Error('not implemented!');

--- a/packages/src/@terra-money/wallet-provider/react/StaticWalletProvider.tsx
+++ b/packages/src/@terra-money/wallet-provider/react/StaticWalletProvider.tsx
@@ -50,6 +50,9 @@ export function StaticWalletProvider({
       sign: () => {
         throw new Error('not implemented!');
       },
+      signBytes: () => {
+        throw new Error('not implemented!');
+      },
       recheckStatus: () => {
         throw new Error('not implemented!');
       },

--- a/packages/src/@terra-money/wallet-provider/react/WalletProvider.tsx
+++ b/packages/src/@terra-money/wallet-provider/react/WalletProvider.tsx
@@ -97,6 +97,7 @@ export function WalletProvider({
       disconnect: controller.disconnect,
       post: controller.post,
       sign: controller.sign,
+      signBytes: controller.signBytes,
       recheckStatus: controller.recheckStatus,
       isChromeExtensionCompatibleBrowser:
         controller.isChromeExtensionCompatibleBrowser,
@@ -110,6 +111,7 @@ export function WalletProvider({
     controller.install,
     controller.post,
     controller.sign,
+    controller.signBytes,
     controller.recheckStatus,
     controller.isChromeExtensionCompatibleBrowser,
     states,

--- a/packages/src/components/SignBytesSample.tsx
+++ b/packages/src/components/SignBytesSample.tsx
@@ -1,0 +1,79 @@
+import {
+  CreateTxFailed,
+  SignBytesResult,
+  Timeout,
+  TxFailed,
+  TxUnspecifiedError,
+  useConnectedWallet,
+  UserDenied,
+} from '@terra-money/wallet-provider';
+import React, { useCallback, useState } from 'react';
+
+export function SignBytesSample() {
+  const [signBytesResult, setSignBytesResult] =
+    useState<SignBytesResult | null>(null);
+  const [txError, setTxError] = useState<string | null>(null);
+
+  const connectedWallet = useConnectedWallet();
+
+  const send = useCallback(() => {
+    if (!connectedWallet) {
+      return;
+    }
+
+    setSignBytesResult(null);
+
+    connectedWallet
+      .signBytes(Buffer.from(new Uint8Array([1, 2, 3, 4])))
+      .then((nextSignBytesResult: SignBytesResult) => {
+        console.log('SignBytesSample.tsx..()', nextSignBytesResult);
+
+        setSignBytesResult(nextSignBytesResult);
+      })
+      .catch((error: unknown) => {
+        if (error instanceof UserDenied) {
+          setTxError('User Denied');
+        } else if (error instanceof CreateTxFailed) {
+          setTxError('Create Tx Failed: ' + error.message);
+        } else if (error instanceof TxFailed) {
+          setTxError('Tx Failed: ' + error.message);
+        } else if (error instanceof Timeout) {
+          setTxError('Timeout');
+        } else if (error instanceof TxUnspecifiedError) {
+          setTxError('Unspecified Error: ' + error.message);
+        } else {
+          setTxError(
+            'Unknown Error: ' +
+              (error instanceof Error ? error.message : String(error)),
+          );
+        }
+      });
+  }, [connectedWallet]);
+
+  return (
+    <div>
+      <h1>Sign Bytes Sample</h1>
+      {connectedWallet?.availableSign && !signBytesResult && !txError && (
+        <button onClick={() => send()}>
+          Sign bytes <code>Buffer.from(new Uint8Array([1, 2, 3, 4]))</code>
+        </button>
+      )}
+      {signBytesResult && (
+        <>
+          <pre>{JSON.stringify(signBytesResult, null, 2)}</pre>
+          <button onClick={() => setSignBytesResult(null)}>Clear Result</button>
+        </>
+      )}
+      {txError && (
+        <>
+          <pre>{txError}</pre>
+          <button onClick={() => setTxError(null)}>Clear Error</button>
+        </>
+      )}
+      {!connectedWallet && <p>Wallet not connected!</p>}
+      {connectedWallet && !connectedWallet.availableSign && (
+        <p>Can not sign Tx</p>
+      )}
+    </div>
+  );
+}

--- a/packages/src/index.tsx
+++ b/packages/src/index.tsx
@@ -1,10 +1,11 @@
 import { getChainOptions, WalletProvider } from '@terra-money/wallet-provider';
+import { ConnectSample } from 'components/ConnectSample';
+import { QuerySample } from 'components/QuerySample';
+import { SignBytesSample } from 'components/SignBytesSample';
+import { SignSample } from 'components/SignSample';
+import { TxSample } from 'components/TxSample';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { ConnectSample } from './components/ConnectSample';
-import { QuerySample } from './components/QuerySample';
-import { SignSample } from './components/SignSample';
-import { TxSample } from './components/TxSample';
 
 function App() {
   return (
@@ -20,6 +21,7 @@ function App() {
       <QuerySample />
       <TxSample />
       <SignSample />
+      <SignBytesSample />
     </main>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3151,9 +3151,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terra-money/terra.js@npm:2.0.11":
-  version: 2.0.11
-  resolution: "@terra-money/terra.js@npm:2.0.11"
+"@terra-money/terra.js@npm:2.0.15":
+  version: 2.0.15
+  resolution: "@terra-money/terra.js@npm:2.0.15"
   dependencies:
     axios: ^0.21.1
     bech32: ^2.0.0
@@ -3167,7 +3167,7 @@ __metadata:
     tmp: ^0.2.1
     utf-8-validate: ^5.0.5
     ws: ^7.4.2
-  checksum: 813cd40f8ca425850ccca9a781ce95f76c62cff2b2a6e87cfdee69bb394332d0cc2a3aeff1d02faa794f6e591b1e26c476af1db221932401c7614ef8a6f9350a
+  checksum: eabe66526a3e0a9842c7175e5a82a1cbdcfc384543ad6e8d52b27193c01f35d971fc1b6d4b1458de77f4af3280bfea19fadd87c897182a1f7bf820dd2f772dca
   languageName: node
   linkType: hard
 
@@ -13737,7 +13737,7 @@ fsevents@^1.2.7:
     "@sentry/tracing": ^6.11.0
     "@terra-dev/web-connector-controller": ^0.7.0
     "@terra-dev/web-connector-interface": ^0.7.0
-    "@terra-money/terra.js": ^2.0.1
+    "@terra-money/terra.js": ^2.0.15
     "@testing-library/jest-dom": ^5.14.1
     "@types/jest": ^26.0.24
     "@types/puppeteer": ^5.4.4


### PR DESCRIPTION
# How to install

```
yarn add @terra-money/wallet-provider@next # or 2.4.0-alpha.1
```

# Warning

This update not work on the released Terra Station Extension. (`signBytes()` feature is in testing on internal)

# TODO

- [x] Add `signBytes()` method
- [ ] Update templates