### PR TITLE
feat: add sign-bytes to legacy-extension-connector

### DIFF
--- a/packages/.packages.json
+++ b/packages/.packages.json
@@ -5,7 +5,7 @@
     "tag": "latest"
   },
   "@terra-money/*": {
-    "version": "3.2.0",
-    "tag": "latest"
+    "version": "3.3.0-alpha.1",
+    "tag": "next"
   }
 }

--- a/packages/src/@terra-money/wallet-controller/modules/legacy-extension/createFixedExtension.ts
+++ b/packages/src/@terra-money/wallet-controller/modules/legacy-extension/createFixedExtension.ts
@@ -22,7 +22,15 @@ type SignResponse = {
     result: Tx.Data;
   };
 };
-type SignBytesResponse = any;
+type SignBytesResponse = {
+  payload: {
+    result: {
+      public_key: string;
+      recid: number;
+      signature: string;
+    };
+  };
+};
 type InfoResponse = NetworkInfo;
 
 export interface FixedExtension {
@@ -237,7 +245,7 @@ export function createFixedExtension(identifier: string): FixedExtension {
   }
 
   function signBytes(bytes: Buffer) {
-    return new Promise<SignResponse>((...resolver) => {
+    return new Promise<SignBytesResponse>((...resolver) => {
       _inTransactionProgress = true;
 
       const id = extension.signBytes({


### PR DESCRIPTION
# Test

`signBytes()` added extension will be updated soon.

### Install

```sh
npm install @terra-money/wallet-provider@next # or 3.3.0-alpha.1
```

### If you want to test now

```sh
git clone -b extension/sign-bytes https://github.com/terra-money/station.git
cd station
npm install
npm ext
```

Go to `chrome://extensions/`

Enable the developer mode

Load unpacked directory that `~project-root/build` by "Load unpacked" button