### PR TITLE
fix: terra.js version conflict and ignore unnecessary source map warnings

### DIFF
--- a/templates/create-react-app/config-overrides.js
+++ b/templates/create-react-app/config-overrides.js
@@ -7,6 +7,8 @@ module.exports = function override(config, env) {
     buffer: require.resolve('buffer'),
   };
 
+  config.ignoreWarnings = [/Failed to parse source map/];
+
   config.plugins.push(
     new ProvidePlugin({
       Buffer: ['buffer', 'Buffer'],

--- a/templates/create-react-app/package.json
+++ b/templates/create-react-app/package.json
@@ -34,7 +34,7 @@
     ]
   },
   "dependencies": {
-    "@terra-money/terra.js": "^3.0.2",
+    "@terra-money/terra.js": "3.0.9",
     "@terra-money/wallet-provider": "^3.6.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
NOTE: source map warning should be fixed in upcoming version of webpack