### PR TITLE
fix: downgrade terra.js to 3.0.9

### DIFF
--- a/templates/create-react-app/config-overrides.js
+++ b/templates/create-react-app/config-overrides.js
@@ -14,5 +14,7 @@ module.exports = function override(config, env) {
     }),
   );
 
+  config.ignoreWarnings = [/Failed to parse source map/];
+
   return config;
 };

--- a/templates/create-react-app/package.json
+++ b/templates/create-react-app/package.json
@@ -34,7 +34,7 @@
     ]
   },
   "dependencies": {
-    "@terra-money/terra.js": "^3.0.2",
+    "@terra-money/terra.js": "3.0.9",
     "@terra-money/wallet-provider": "^3.6.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/templates/lit/package.json
+++ b/templates/lit/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@terra-money/terra.js": "^3.0.2",
+    "@terra-money/terra.js": "3.0.9",
     "@terra-money/wallet-provider": "^3.6.5",
     "buffer": "^6.0.3",
     "lit": "^2.0.2",

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -8,7 +8,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@terra-money/terra.js": "^3.0.2",
+    "@terra-money/terra.js": "3.0.9",
     "@terra-money/wallet-provider": "^3.6.5",
     "next": "^12.0.9",
     "react": "^17.0.2",

--- a/templates/svelte/package.json
+++ b/templates/svelte/package.json
@@ -18,7 +18,7 @@
     ]
   },
   "dependencies": {
-    "@terra-money/terra.js": "^3.0.2",
+    "@terra-money/terra.js": "3.0.9",
     "@terra-money/wallet-provider": "^3.6.5",
     "buffer": "^6.0.3",
     "rxjs": "^7.4.0",

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@terra-money/terra.js": "^3.0.2",
+    "@terra-money/terra.js": "3.0.9",
     "@terra-money/wallet-provider": "^3.6.5",
     "buffer": "^6.0.3",
     "react": "^17.0.2",

--- a/templates/vue/package.json
+++ b/templates/vue/package.json
@@ -22,7 +22,7 @@
     ]
   },
   "dependencies": {
-    "@terra-money/terra.js": "^3.0.2",
+    "@terra-money/terra.js": "3.0.9",
     "@terra-money/wallet-provider": "^3.6.5",
     "buffer": "^6.0.3",
     "rxjs": "^7.4.0",


### PR DESCRIPTION
- Downgrade to 3.0.9 until `BIP32` depdency issue is resolved in `terra.js`
- Ignore source mapper errors (unsubstantive) 
 