### PR TITLE
fix: wallet connect transaction serialization on Terra Classic.

### DIFF
--- a/packages/src/@terra-money/wallet-controller/modules/walletconnect/connect.ts
+++ b/packages/src/@terra-money/wallet-controller/modules/walletconnect/connect.ts
@@ -238,9 +238,11 @@ export function connect(
     }
 
     const id = Date.now();
+    // @ts-ignore
+    const { isClassic } = tx;
 
     const serializedTxOptions = {
-      msgs: tx.msgs.map((msg) => msg.toJSON()),
+      msgs: tx.msgs.map((msg) => msg.toJSON(isClassic)),
       fee: tx.fee?.toJSON(),
       memo: tx.memo,
       gas: tx.gas,

--- a/packages/src/@terra-money/wallet-controller/modules/walletconnect/connect.ts
+++ b/packages/src/@terra-money/wallet-controller/modules/walletconnect/connect.ts
@@ -243,7 +243,7 @@ export function connect(
 
     const serializedTxOptions = {
       msgs: tx.msgs.map((msg) => msg.toJSON(isClassic)),
-      fee: tx.fee?.toJSON(),
+      fee: tx.fee?.toJSON(isClassic),
       memo: tx.memo,
       gas: tx.gas,
       gasPrices: tx.gasPrices?.toString(),


### PR DESCRIPTION
This is a quick fix linked to an issue:
https://github.com/terra-money/wallet-provider/issues/97

I have tested it on the IOS simulator with the latest Terra Station Mobile to verify everything is working fine.