### PR TITLE
feat: allow custom plugins to be injected

### DIFF
--- a/packages/.packages.json
+++ b/packages/.packages.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://rocket-hangar.github.io/rocket-punch/schemas/packages.json",
   "@terra-money/use-wallet": {
-    "version": "3.9.4",
+    "version": "3.10.0-alpha.1",
     "tag": "latest"
   },
   "@terra-money/*": {
-    "version": "3.9.4",
+    "version": "3.10.0-alpha.1",
     "tag": "latest"
   }
 }

--- a/packages/src/@terra-money/wallet-controller/controller.ts
+++ b/packages/src/@terra-money/wallet-controller/controller.ts
@@ -162,11 +162,7 @@ export interface WalletControllerOptions
   ) => boolean;
 }
 
-type Connections = {
-  [Key: string]: Connection;
-};
-
-const CONNECTIONS: Connections = {
+const CONNECTIONS = {
   [ConnectType.READONLY]: {
     type: ConnectType.READONLY,
     name: 'View an address',
@@ -177,7 +173,7 @@ const CONNECTIONS: Connections = {
     name: 'Wallet Connect',
     icon: 'https://assets.terra.money/icon/wallet-provider/walletconnect.svg',
   } as Connection,
-};
+} as const;
 
 const DEFAULT_WAITING_CHROME_EXTENSION_INSTALL_CHECK = 1000 * 3;
 
@@ -364,11 +360,8 @@ export class WalletController {
                 ),
               );
             }
-          } else if (
-            connectType === ConnectType.PLUGINS &&
-            this.options.plugins
-          ) {
-            for (const plugin of this.options.plugins) {
+          } else if (connectType === ConnectType.PLUGINS) {
+            for (const plugin of this.options.plugins || []) {
               connections.push(
                 memoConnection(
                   ConnectType.PLUGINS,

--- a/packages/src/@terra-money/wallet-controller/modules/wallet-plugin/types.ts
+++ b/packages/src/@terra-money/wallet-controller/modules/wallet-plugin/types.ts
@@ -1,0 +1,22 @@
+import { CreateTxOptions } from '@terra-money/terra.js';
+import { NetworkInfo, TxResult } from '@terra-money/wallet-types';
+import { TerraWebExtensionConnector } from '@terra-money/web-extension-interface';
+
+export interface WalletPlugin {
+  name: string;
+  type: string;
+  icon: string;
+  identifier: string;
+  createSession: (
+    networks: NetworkInfo[],
+  ) => Promise<WalletPluginSession | null>;
+}
+
+export interface WalletPluginSession {
+  network: NetworkInfo | null;
+  terraAddress: string | null;
+  connect: () => Promise<void>;
+  disconnect: () => Promise<void>;
+
+  post: (txn: CreateTxOptions) => Promise<TxResult>;
+}

--- a/packages/src/@terra-money/wallet-provider/WalletProvider.tsx
+++ b/packages/src/@terra-money/wallet-provider/WalletProvider.tsx
@@ -32,6 +32,7 @@ export function WalletProvider({
   selectExtension,
   waitingChromeExtensionInstallCheck,
   dangerously__chromeExtensionCompatibleBrowserCheck,
+  plugins,
 }: WalletProviderProps) {
   const [controller] = useState<WalletController>(
     () =>
@@ -44,6 +45,7 @@ export function WalletProvider({
         selectExtension,
         waitingChromeExtensionInstallCheck,
         dangerously__chromeExtensionCompatibleBrowserCheck,
+        plugins,
       }),
   );
 

--- a/packages/src/@terra-money/wallet-types/types.ts
+++ b/packages/src/@terra-money/wallet-types/types.ts
@@ -59,6 +59,9 @@ export enum ConnectType {
 
   /** Read only mode - View an address */
   READONLY = 'READONLY',
+
+  /** Plugins injected from app */
+  PLUGINS = 'PLUGINS',
 }
 
 export interface Connection {


### PR DESCRIPTION
Added a way to inject new wallet plugins. Example: injected a web3auth plugin to allow social / email connect

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/3447315/183854059-2d275e1e-c88b-4ef8-9922-e743d1c0220a.png">
