### PR TITLE
added optional metadata for plugins to add data

### DIFF
--- a/packages/.packages.json
+++ b/packages/.packages.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://rocket-hangar.github.io/rocket-punch/schemas/packages.json",
   "@terra-money/use-wallet": {
-    "version": "3.11.0",
+    "version": "3.11.1",
     "tag": "latest"
   },
   "@terra-money/*": {
-    "version": "3.11.0",
+    "version": "3.11.1",
     "tag": "latest"
   }
 }

--- a/packages/src/@terra-money/wallet-controller/controller.ts
+++ b/packages/src/@terra-money/wallet-controller/controller.ts
@@ -983,7 +983,7 @@ export class WalletController {
         {
           connectType: ConnectType.PLUGINS,
           terraAddress: session.terraAddress || 'not created',
-          metadata: session.getMetadata ? session.getMetadata() : undefined,
+          metadata: session.getMetadata && session.getMetadata(),
         },
       ],
       supportFeatures: WALLETCONNECT_SUPPORT_FEATURES,

--- a/packages/src/@terra-money/wallet-controller/controller.ts
+++ b/packages/src/@terra-money/wallet-controller/controller.ts
@@ -983,6 +983,7 @@ export class WalletController {
         {
           connectType: ConnectType.PLUGINS,
           terraAddress: session.terraAddress || 'not created',
+          metadata: session.getMetadata ? session.getMetadata() : undefined,
         },
       ],
       supportFeatures: WALLETCONNECT_SUPPORT_FEATURES,

--- a/packages/src/@terra-money/wallet-controller/modules/wallet-plugin/types.ts
+++ b/packages/src/@terra-money/wallet-controller/modules/wallet-plugin/types.ts
@@ -16,6 +16,7 @@ export interface WalletPluginSession {
   terraAddress: string | null;
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
+  getMetadata: () => { [key: string]: any };
 
   post: (txn: CreateTxOptions) => Promise<TxResult>;
 }

--- a/packages/src/@terra-money/wallet-controller/modules/wallet-plugin/types.ts
+++ b/packages/src/@terra-money/wallet-controller/modules/wallet-plugin/types.ts
@@ -16,7 +16,7 @@ export interface WalletPluginSession {
   terraAddress: string | null;
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
-  getMetadata: () => { [key: string]: any };
+  getMetadata?: () => { [key: string]: any };
 
   post: (txn: CreateTxOptions) => Promise<TxResult>;
 }

--- a/packages/src/@terra-money/wallet-types/types.ts
+++ b/packages/src/@terra-money/wallet-types/types.ts
@@ -85,6 +85,7 @@ export interface WalletInfo {
   connectType: ConnectType;
   terraAddress: string;
   design?: string;
+  metadata?: { [key: string]: any };
 }
 
 export type WalletStates =


### PR DESCRIPTION
Allow plugins to add metadata to wallet info. This helps to expose some data such as email, name and type when plugins are used.

<img width="878" alt="image" src="https://user-images.githubusercontent.com/3447315/186557933-d8557820-7956-402c-a366-f6d798622caf.png">
