### PR TITLE
fix: use station.money urls

### DIFF
--- a/packages/src/@terra-money/wallet-controller/getChainOptions.ts
+++ b/packages/src/@terra-money/wallet-controller/getChainOptions.ts
@@ -41,7 +41,7 @@ const FALLBACK: WalletControllerChainOptions = {
 let cache: WalletControllerChainOptions;
 
 export async function getChainOptions(): Promise<WalletControllerChainOptions> {
-  return fetch('https://assets.terra.money/chains.json')
+  return fetch('https://assets.station.money/chains.json')
     .then((res) => res.json())
     .then((data: Record<string, ChainInfo>) => {
       const chains = Object.values(data);

--- a/packages/src/components/PostSample.tsx
+++ b/packages/src/components/PostSample.tsx
@@ -84,7 +84,7 @@ export function PostSample() {
           <pre>{JSON.stringify(txResult, null, 2)}</pre>
           {connectedWallet && txResult && (
             <a
-              href={`https://finder.terra.money/${connectedWallet.network.chainID}/tx/${txResult.result.txhash}`}
+              href={`https://finder.station.money/${connectedWallet.network.chainID}/tx/${txResult.result.txhash}`}
               target="_blank"
               rel="noreferrer"
             >

--- a/packages/src/components/SignSample.tsx
+++ b/packages/src/components/SignSample.tsx
@@ -112,7 +112,7 @@ export function SignSample() {
           <pre>{JSON.stringify(txResult, null, 2)}</pre>
           {connectedWallet && txResult && (
             <a
-              href={`https://finder.terra.money/${connectedWallet.network.chainID}/tx/${txResult.txhash}`}
+              href={`https://finder.station.money/${connectedWallet.network.chainID}/tx/${txResult.txhash}`}
               target="_blank"
               rel="noreferrer"
             >

--- a/packages/src/components/TxSample.tsx
+++ b/packages/src/components/TxSample.tsx
@@ -79,7 +79,7 @@ export function TxSample() {
           {connectedWallet && txResult && (
             <div>
               <a
-                href={`https://finder.terra.money/${connectedWallet.network.chainID}/tx/${txResult.result.txhash}`}
+                href={`https://finder.station.money/${connectedWallet.network.chainID}/tx/${txResult.result.txhash}`}
                 target="_blank"
                 rel="noreferrer"
               >

--- a/templates/lit/src/components/tx-sample.ts
+++ b/templates/lit/src/components/tx-sample.ts
@@ -32,7 +32,7 @@ export class FormRenderer extends LitElement {
         <pre>${JSON.stringify(this.txResult, null, 2)}</pre>
         <div>
           <a
-            href="https://finder.terra.money/${this.connectedWallet.network
+            href="https://finder.station.money/${this.connectedWallet.network
               .chainID}/tx/${this.txResult.result.txhash}"
             target="_blank"
             rel="noreferrer"

--- a/templates/next/pages/tx-sample.tsx
+++ b/templates/next/pages/tx-sample.tsx
@@ -76,7 +76,7 @@ export default function TxSample() {
           {connectedWallet && txResult && (
             <div>
             <a
-              href={`https://finder.terra.money/${connectedWallet.network.chainID}/tx/${txResult.result.txhash}`}
+              href={`https://finder.station.money/${connectedWallet.network.chainID}/tx/${txResult.result.txhash}`}
               target="_blank"
               rel="noreferrer"
             >

--- a/templates/vite/src/components/SignSample.tsx
+++ b/templates/vite/src/components/SignSample.tsx
@@ -94,7 +94,7 @@ export function SignSample() {
           <pre>{JSON.stringify(txResult, null, 2)}</pre>
           {connectedWallet && txResult && (
             <a
-              href={`https://finder.terra.money/${connectedWallet.network.chainID}/tx/${txResult.txhash}`}
+              href={`https://finder.station.money/${connectedWallet.network.chainID}/tx/${txResult.txhash}`}
               target="_blank"
               rel="noreferrer"
             >

--- a/templates/vue/src/components/TxSampleForm.vue
+++ b/templates/vue/src/components/TxSampleForm.vue
@@ -71,7 +71,7 @@ function clearResult() {
     <pre>{{ JSON.stringify(txResult, null, 2) }}</pre>
     <div>
       <a
-        href="https://finder.terra.money/{{connectedWallet.network.chainID}}/tx/{{txResult.result.txhash}}"
+        href="https://finder.station.money/{{connectedWallet.network.chainID}}/tx/{{txResult.result.txhash}}"
         target="_blank"
         rel="noreferrer"
         >Open tx result in explorer</a


### PR DESCRIPTION
replaced all URLs (terra.money) with the new ones for which I found a direct replacement on station.money.
Hope you dont need this.
There are still many terra.money urls.
